### PR TITLE
Fix for AMTabViewDelegate, add delegate selected CV

### DIFF
--- a/AMTabView/Classes/AMTabsViewController.swift
+++ b/AMTabView/Classes/AMTabsViewController.swift
@@ -25,10 +25,29 @@
 
 import UIKit
 
-open class AMTabsViewController: UIViewController {
+///
+/// To use any view controller as a tab you need to implement protocol.
+///
+public protocol TabItem {
+  ///
+  /// Image or title to show on the tab.
+  ///
+  var tabImage: UIImage? { get }
+}
+
+public protocol ControllerDelegate {
+  ///
+  /// Notify that CV did set
+  ///
+  func tabBarController(didSelect viewController: UIViewController)
+}
+
+open class AMTabsViewController: UIViewController, AMTabViewDelegate {
 
   // MARK: - Properties
-
+    
+  public var cvDelegate: ControllerDelegate?
+    
   ///
   /// Selected tab index. The default value is `nil`.
   /// Changing this value will change the current select tab.
@@ -72,7 +91,6 @@ open class AMTabsViewController: UIViewController {
 
   override open func viewDidLoad() {
     super.viewDidLoad()
-
   }
 
   private func initViews() {
@@ -144,6 +162,13 @@ open class AMTabsViewController: UIViewController {
     })
   }
 
+  ///
+  /// Override the method to get the tab selected actions.
+  ///
+  open func tabDidSelectAt(index: Int) {
+    selectedTabIndex = index
+  }
+
   private func moveToViewContollerAt(index: Int) {
 
     guard index != lastSelectedViewIndex else {
@@ -160,29 +185,8 @@ open class AMTabsViewController: UIViewController {
       contoller.didMove(toParent: self)
       newView?.frame = containerView.bounds
     }
-
+    // Notify delegate that CV did set
+    cvDelegate?.tabBarController(didSelect: contoller)
     lastSelectedViewIndex = index
   }
-
-}
-
-///
-/// To use any view controller as a tab you need to implement protocol.
-///
-public protocol TabItem {
-  ///
-  /// Image or title to show on the tab.
-  ///
-  var tabImage: UIImage? { get }
-}
-
-extension AMTabsViewController: AMTabViewDelegate {
-
-  ///
-  /// Override the method to get the tab selected actions.
-  ///
-  public func tabDidSelectAt(index: Int) {
-    selectedTabIndex = index
-  }
-
 }

--- a/Example/AMTabView/ViewControllers/ViewController.swift
+++ b/Example/AMTabView/ViewControllers/ViewController.swift
@@ -27,13 +27,23 @@ import UIKit
 import AMTabView
 
 class ViewController: AMTabsViewController {
+  
+  override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+      super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+      super.cvDelegate = self
+      setTabsControllers()
+  }
+  
+  required init?(coder aDecoder: NSCoder) {
+      super.init(coder: aDecoder)
+      super.cvDelegate = self
+      setTabsControllers()
+  }
 
   // MARK: - ViewController lifecycle
   
   override func viewDidLoad() {
     super.viewDidLoad()
-
-    setTabsControllers()
   }
 
   private func setTabsControllers() {
@@ -50,5 +60,23 @@ class ViewController: AMTabsViewController {
       ghostViewController
     ]
   }
+  
+  // Optional param, triggered always when user tabbed on tab bar element
+  override func tabDidSelectAt(index: Int) {
+      super.tabDidSelectAt(index: index)
+  }
+  
+}
+
+// MARK: - TabBarControllerDelegate
+
+extension ViewController: ControllerDelegate {
+
+  func tabBarController(didSelect viewController: UIViewController) {
+    print(viewController)
+    // If you were use separate root CV
+//      AppRouter.router.tabBarDidChangedTo(controller: viewController)
+  }
+
 }
 


### PR DESCRIPTION
Fix for AMTabViewDelegate –– non objC method can't override from extension and overriding non-open instance method outside of its defining module. Add delegate to notify what selected CV in Root, if we had use separate roots on that CV. And update example project